### PR TITLE
Remove redundant suggestions for collaboration

### DIFF
--- a/contributor-guidelines.rst
+++ b/contributor-guidelines.rst
@@ -18,7 +18,6 @@ Below are several suggestions:
 * Write as much as is necessary, but as little as you can get away with. 
 * Suggest improvements to the RFC, don't just shoot it down. When disagreeing, provide substantial reason instead of just saying "no". Try to outline specific points you disagree with and suggest ways of improvement. And remember, you can suggest improvements to an RFC even if you would not vote to support the RFC.
 * Don't use hyperbole to defend your arguments.
-* Don't send a "quick email", especially during a heated debate.
 * Think before you send "reply". Consider how the other party is likely to feel with the content. And, how you would feel if the same text was directed at you. Emotions are important and difficult, especially when you have never met in person.
 * Debate the technical issues, and never attack a person's opinion. People will disagree, so be it.
 


### PR DESCRIPTION
The following two lines are a bit redundant:

```
* Don't send a "quick email", especially during a heated debate.
* Think before you send "reply". Consider how the other party is likely to feel with the content. And, how you would feel if the same text was directed at you. Emotions are important and difficult, especially when you have never met in person.
```

So I suggest remove the first one as it doesn't really add anything that **think before you reply** doesn't cover already.
