### PR TITLE
Port applicable parts of Contributor Covenant v1.4

### DIFF
--- a/code-of-conduct.rst
+++ b/code-of-conduct.rst
@@ -55,10 +55,10 @@ Unacceptable Behaviour
 
 Examples of unacceptable behaviour by participants include:
 
-- The use of sexualized language or imagery
-- Personal attacks
-- Trolling or insulting/derogatory comments
-- Public or private harassment relating to project concerns
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
 - Publishing other's private information, such as physical or electronic
   addresses, without explicit permission (AKA doxing) 
 - Coercing other members to vote for a particular option on an RFC, or to
@@ -69,16 +69,15 @@ Examples of unacceptable behaviour by participants include:
 Application of the Code of Conduct
 ----------------------------------
 
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviours that they deem 
 threatening, offensive, or harmful.
-
-By adopting this Code of Conduct, project maintainers commit themselves to
-fairly and consistently applying these principles to every aspect of managing
-this project. Project maintainers who do not follow the Code of Conduct may be
-permanently removed from the project team.
 
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community —
@@ -93,3 +92,7 @@ complaints will be reviewed and investigated as outlined
 necessary and appropriate to the circumstances. Maintainers are obligated to
 maintain confidentiality with regard to both the reporter of an incident, and
 the accused, and expect all parties to assist in ensuring this.
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.


### PR DESCRIPTION
Hey there! So, version 1.4 of the Contributor Covenant was released recently. It tweaks and tidies up some of the examples, among other things. I _think_ some of the changes are at least partially the result of input from people from this community, so it seemed like a nice idea to try to port as much of it over as possible.

This is my attempt. I left this repo's custom positive behaviour examples intact, since they're PHP-specific now and totally diverged. My thinking was basically: update the bits where it still looks like Contributor Covenant v1.3. Maybe in the long run, following each minor version update like this isn't the plan, but I'm hoping at least this one is helpful. I certainly see stuff in this diff that I think looks like it'll help move things forward :+1:
