### PR TITLE
Remove the word 'Trolling'

### DIFF
--- a/code-of-conduct.rst
+++ b/code-of-conduct.rst
@@ -57,7 +57,7 @@ Examples of unacceptable behaviour by participants include:
 
 - The use of sexualized language or imagery and unwelcome sexual attention or
   advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
+- Insulting/derogatory comments, and personal or political attacks
 - Public or private harassment
 - Publishing other's private information, such as physical or electronic
   addresses, without explicit permission (AKA doxing) 


### PR DESCRIPTION
I feel the word 'trolling' is not clear enough defined in modern language. Multiple things can be mistaken for trolling while they are meant as comments or a grain of sarcasm. I can see comments taken for trolling by someone very easily when they disagree. I would encourage us to remove the word as I think "Insulting/derogatory comments, and personal or political attacks" defines the boundaries much more clearly.
