### PR TITLE
Define project manager duties when removing messages

### DIFF
--- a/code-of-conduct.rst
+++ b/code-of-conduct.rst
@@ -77,7 +77,9 @@ Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviours that they deem 
-threatening, offensive, or harmful.
+threatening, offensive, or harmful. Project maintainers have to ensure
+that the offending messages are saved for review and the reasons for
+removal are clearly stated.
 
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community —


### PR DESCRIPTION
I think we should ensure that project managers cannot just randomly delete things. As a non native speaker i have a hard time phrasing this correctly, but basically the deletion needs to be traceable by other project managers. Without having a clear example, I have seen in the past that in other projects it could be come an issue if a project manager gets into a heated discussion wiht someone else and deletes comments without the ability for others to review the process.
