### PR TITLE
Fix external link markup syntax

### DIFF
--- a/procedures.rst
+++ b/procedures.rst
@@ -54,8 +54,9 @@ Reasonable Person Test
 ----------------------
 
 To determine if the incident is a violation or not, the Community Mediation
-Team shall use the
-[[https://en.wikipedia.org/wiki/Reasonable_person|Reasonable Person Test]]. 
+Team shall use the `Reasonable Person Test`_.
+
+.. _`Reasonable Person Test`: https://en.wikipedia.org/wiki/Reasonable_person
 
 The following four points shall be taken into account for any incident:
 


### PR DESCRIPTION
Fix the external link to 'Reasonable Person Test' to use the right RST markup syntax (which I had to look up. It really is very obscure in this RST format)